### PR TITLE
Day 2: group-based provisioning + least-priv S3 writer for nino-iam-d…

### DIFF
--- a/docs/day2-least-privilege-demo.md
+++ b/docs/day2-least-privilege-demo.md
@@ -1,0 +1,25 @@
+# Day 2 — Group-based Provisioning & Scoped S3 Write
+
+**Goal:** Provision IAM via **groups**, then enforce **least privilege** by granting write to a single S3 bucket.
+
+## Groups
+- `baseline-self-service` → AWS managed: **IAMUserChangePassword**
+- `dev-readonly` → AWS managed: **ReadOnlyAccess**
+- `s3-nino-eiam-writer` → customer-managed: **S3Write-nino-iam-demo-eiam**
+
+## Users (test matrix)
+- `alice-readonly` → baseline + readonly (list/download; upload fails)
+- `ben-s3writer` → baseline + scoped S3 writer (upload/download OK in target bucket; S3 bucket list may show AccessDenied)
+- `cara-baseline` → baseline only (no S3)
+- `nino-dev-demo` → initial testing identity
+
+## Expected Results
+- Upload to **nino-iam-demo-eiam** only works for users in `s3-nino-eiam-writer`.
+- Bucket listing page may fail unless you add this convenience permission:
+```json
+{
+  "Sid": "AllowListAllBucketsForConsole",
+  "Effect": "Allow",
+  "Action": "s3:ListAllMyBuckets",
+  "Resource": "*"
+}

--- a/policies/S3Write-nino-iam-demo-eiam.json
+++ b/policies/S3Write-nino-iam-demo-eiam.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListAndLocateBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::nino-iam-demo-eiam"
+    },
+    {
+      "Sid": "RWObjectsInBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::nino-iam-demo-eiam/*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements Day 2 from the 6-Week IAM plan (Chapter 4 focus): create IAM users and provision access via groups, then enforce least privilege for a single S3 bucket.

## What changed
- Added customer-managed policy for scoped S3 access:
  - `policies/S3Write-nino-iam-demo-eiam.json`
- Added walkthrough/docs:
  - `docs/day2-least-privilege-demo.md`

## How to test
1) alice-readonly → S3 upload to `nino-iam-demo-eiam` **fails** (AccessDenied); download **works**.
2) ben-s3writer → open bucket URL directly; **upload + download succeed**; S3 bucket list may show **AccessDenied** (no `s3:ListAllMyBuckets`).
3) cara-baseline → S3 console shows **AccessDenied**.

## Notes
- Policies attached to groups only (clean provisioning).
- Optional console convenience (not added): allow `s3:ListAllMyBuckets` for listing.
- No public access configured.

## Next
Day 3: Use Policy Simulator to verify the exact allows/denies for these users.
